### PR TITLE
ci: configure GitHub Action to auto-commit formatting and lint fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,16 +12,34 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.head_ref || github.ref_name }}
 
-    - name: Check formatting with Ruff (Warn only)
-      # This step checks for formatting issues but will NOT FAIL the job.
-      # It will show a warning annotation instead.
+    - name: Check and fix linting with Ruff
       uses: astral-sh/ruff-action@v3
       with:
-        args: 'format --check'
+        args: 'check --fix'
+      continue-on-error: true
+
+    - name: Format code with Ruff
+      uses: astral-sh/ruff-action@v3
+      with:
+        args: 'format'
+
+    - name: Commit changes
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: "style: apply Ruff auto-formatting"
+
+    - name: Verify linting passes
+      uses: astral-sh/ruff-action@v3
+      with:
+        args: 'check'
 
   typing:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR updates the GitHub Actions workflow `main.yml` to automatically fix code formatting and linting errors using Ruff. 

Instead of just warning or failing, the workflow now checks out the code, applies fixes using `ruff check --fix` and `ruff format`, and commits any changes back to the branch using `stefanzweifel/git-auto-commit-action`. A final `ruff check` step ensures that any unfixable lint errors still fail the CI job properly. The necessary `contents: write` permissions and correct reference checkout behavior have been configured to support this.

---
*PR created automatically by Jules for task [15552266163164775401](https://jules.google.com/task/15552266163164775401) started by @kastnerp*