### PR TITLE
🎨 Palette: Improve error message clarity for malformed files

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Improve CLI error messages
+**Learning:** Raw stack traces from CLI tools are intimidating to users, particularly when the root cause is something simple like a malformed or empty data file. Users should be given clear and actionable feedback rather than a full exception stack trace.
+**Action:** When working on CLI tools, identify common failures (e.g., malformed input files) and handle them with custom exceptions and user-friendly console logs.

--- a/openfoam_residuals/filesystem.py
+++ b/openfoam_residuals/filesystem.py
@@ -10,6 +10,14 @@ import pandas as pd
 from openfoam_residuals import utils
 
 
+class DataParseError(Exception):
+    """Raised when a residual file cannot be parsed."""
+
+    def __init__(self, file: Path, reason: str) -> None:
+        """Initialize the exception with the file and reason."""
+        super().__init__(f"File '{file}' {reason}")
+
+
 def find_residual_files(w_dir: Path) -> list[Path]:
     """Return a list of all residuals*.dat files recursively found under w_dir."""
     return list(Path(w_dir).rglob("residuals*.dat"))
@@ -40,14 +48,20 @@ def pre_parse(file: Path) -> tuple[pd.DataFrame, pd.Series]:
     # ⚡ Bolt: removed `engine="python"` to use pandas default C engine for ~3x faster parsing
     # Note: engine='python' was intentionally removed to allow pandas
     # to use its default C engine, which provides a ~5x speedup for parsing.
-    raw_data = pd.read_csv(
-        io.StringIO(cleaned_text),
-        skiprows=[0],
-        sep=r"\s+",
-        na_values="N/A",
-        on_bad_lines="error",
-    )
-    iterations = raw_data["Time"]
+    try:
+        raw_data = pd.read_csv(
+            io.StringIO(cleaned_text),
+            skiprows=[0],
+            sep=r"\s+",
+            na_values="N/A",
+            on_bad_lines="error",
+        )
+        iterations = raw_data["Time"]
+    except pd.errors.EmptyDataError as err:
+        raise DataParseError(file, "is empty or malformed.") from err
+    except KeyError as err:
+        raise DataParseError(file, "is missing the required 'Time' column.") from err
+
     data = raw_data.drop(["Time"], axis=1)
     data = data.set_index(iterations)
     data = data.dropna(

--- a/openfoam_residuals/main.py
+++ b/openfoam_residuals/main.py
@@ -148,3 +148,6 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         _LOG.warning("Interrupted by user - aborting.")
         sys.exit(130)
+    except fs.DataParseError as e:
+        _LOG.error(str(e))
+        sys.exit(1)


### PR DESCRIPTION
💡 **What**: Added a custom `DataParseError` exception and try/except logic to trap raw pandas stack traces when attempting to parse malformed or empty residual files, mapping them to a clean user-friendly error logged to stderr.

🎯 **Why**: Command line tools should fail gracefully with actionable feedback rather than exposing raw implementation exceptions. When a user provided a bad file, they were greeted with a massive traceback from the `pandas` engine, leading to confusion and poor developer experience (DX). 

📸 **Before/After**:
**Before:**
```
Traceback (most recent call last):
  File "pandas/_libs/index.pyx", line 167...
KeyError: 'Time'
```
**After:**
```
ERROR │ File 'empty.dat' is missing the required 'Time' column.
```

♿ **Accessibility**: Command-line output is significantly more readable and immediately understandable for developers debugging input configurations.

---
*PR created automatically by Jules for task [13335796738108839121](https://jules.google.com/task/13335796738108839121) started by @kastnerp*