### PR TITLE
🎨 Palette: Unify redundant CLI success message

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-03-02 - Expose Examples in CLI Help
 **Learning:** Command-line tools often have great usage examples in their module docstrings, but they are hidden from users. Exposing them in `--help` provides significant onboarding value.
 **Action:** Use `argparse.RawDescriptionHelpFormatter` with `epilog=__doc__` to automatically surface module docstrings as examples in CLI help outputs.
+
+## 2026-03-03 - Unify Redundant CLI Success States
+**Learning:** Redundant success messages (e.g., "Complete!" followed immediately by "Successfully exported X to Y") create visual clutter and reduce the perceived polish of a CLI tool.
+**Action:** When clearing progress indicators, avoid appending an additional success message if the main caller already prints a comprehensive final success state. Always include metrics (like the number of files processed) in the final success message to provide maximum value.

--- a/openfoam_residuals/main.py
+++ b/openfoam_residuals/main.py
@@ -144,7 +144,7 @@ def main() -> None:
             max_iter,
             output_dir=out_dir,
         )
-        print(f"\n✨ Successfully exported plots to {out_dir}")
+        print(f"✨ Successfully exported {len(residual_files)} plot(s) to {out_dir}")
     else:
         _LOG.info("Skipping plot generation (--no-plots).")
 

--- a/openfoam_residuals/plot.py
+++ b/openfoam_residuals/plot.py
@@ -60,5 +60,6 @@ def export_files(
     # ⚡ Bolt: Close the figure explicitly after all plots are done
     plt.close(fig)
     if is_tty and total > 0:
-        sys.stdout.write("\r\033[K✨ Plotting complete!\n")
+        # Clear the progress line so the final success message is clean
+        sys.stdout.write("\r\033[K")
         sys.stdout.flush()


### PR DESCRIPTION
💡 **What:** Unified the CLI success output by removing a redundant intermediate success state and adding the file count metric to the final exit message.

🎯 **Why:** The CLI previously outputted redundant messages back-to-back ("✨ Plotting complete!" followed by "\n✨ Successfully exported plots to..."). Removing this visual clutter and adding context (the number of exported files) makes the CLI feel more polished and provides more value.

📸 **Before/After:**
*Before:*
```
Processing 14 residual file(s)...
✨ Plotting complete!

✨ Successfully exported plots to /app/exports
```
*After:*
```
Processing 14 residual file(s)...
✨ Successfully exported 14 plot(s) to /app/exports
```

♿ **Accessibility/UX:** Improves the signal-to-noise ratio in terminal output.

---
*PR created automatically by Jules for task [12250776907917166298](https://jules.google.com/task/12250776907917166298) started by @kastnerp*