### PR TITLE
🎨 Palette: Add colored logging outputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-03-03 - Unify Redundant CLI Success States
 **Learning:** Redundant success messages (e.g., "Complete!" followed immediately by "Successfully exported X to Y") create visual clutter and reduce the perceived polish of a CLI tool.
 **Action:** When clearing progress indicators, avoid appending an additional success message if the main caller already prints a comprehensive final success state. Always include metrics (like the number of files processed) in the final success message to provide maximum value.
+
+## 2026-03-04 - Colored Terminal Outputs
+**Learning:** Pure CLI tools lack visual hierarchy, making it difficult for users to distinguish errors from informational messages at a glance. Adding ANSI color codes to log levels drastically improves the developer experience with zero additional dependency weight.
+**Action:** When working on CLI tools, implement native ANSI color formatting for console outputs connected to a TTY to provide immediate, accessible visual cues.

--- a/openfoam_residuals/main.py
+++ b/openfoam_residuals/main.py
@@ -19,7 +19,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from openfoam_residuals import filesystem as fs
 from openfoam_residuals import plot as pl
@@ -80,10 +80,36 @@ def parse_args() -> argparse.Namespace:
 
 
 # ───────────────────────────── helpers ──────────────────────────────────
+class _ColorFormatter(logging.Formatter):
+    """Custom formatter to add ANSI colors to log levels if outputting to a TTY."""
+
+    COLORS: ClassVar[dict[int, str]] = {
+        logging.DEBUG: "\033[90m",  # Gray
+        logging.INFO: "\033[36m",  # Cyan
+        logging.WARNING: "\033[33m",  # Yellow
+        logging.ERROR: "\033[31m",  # Red
+        logging.CRITICAL: "\033[31;1m",  # Bold Red
+    }
+    RESET: ClassVar[str] = "\033[0m"
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format the log record with colors if stdout is a TTY."""
+        if sys.stderr.isatty():
+            color = self.COLORS.get(record.levelno, "")
+            original_levelname = record.levelname
+            record.levelname = f"{color}{record.levelname}{self.RESET}"
+            formatted = super().format(record)
+            record.levelname = original_levelname
+            return formatted
+        return super().format(record)
+
+
 def configure_logging(verbosity: int) -> None:
     """Configure logging level based on verbosity."""
     level = logging.WARNING - min(verbosity, 2) * 10
-    logging.basicConfig(level=level, format="%(levelname)s │ %(message)s")
+    handler = logging.StreamHandler()
+    handler.setFormatter(_ColorFormatter("%(levelname)s │ %(message)s"))
+    logging.basicConfig(level=level, handlers=[handler], force=True)
 
 
 def gather_from_dirs(dirs: Iterable[str | Path]) -> list[Path]:


### PR DESCRIPTION
**💡 What:** Implemented a custom `ColorFormatter` (subclassing `logging.Formatter`) to apply native ANSI color codes to terminal log levels (e.g., Red for `ERROR`, Cyan for `INFO`) when the output is connected to a TTY. 
**🎯 Why:** Pure CLI tools lack visual hierarchy, making it difficult for users to distinguish errors from informational messages at a glance. Adding ANSI color codes drastically improves the developer experience and visual feedback without relying on external dependencies like `colorama` or `rich`. 
**📸 Before/After:** N/A for strictly code/stdout CLI changes.
**♿ Accessibility:** Improves usability and at-a-glance scanning of CLI execution logs.

---
*PR created automatically by Jules for task [16973472778346075982](https://jules.google.com/task/16973472778346075982) started by @kastnerp*