### PR TITLE
🎨 Palette: Hide terminal cursor and ensure clean error outputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -17,3 +17,7 @@
 ## 2026-03-04 - Colored Terminal Outputs
 **Learning:** Pure CLI tools lack visual hierarchy, making it difficult for users to distinguish errors from informational messages at a glance. Adding ANSI color codes to log levels drastically improves the developer experience with zero additional dependency weight.
 **Action:** When working on CLI tools, implement native ANSI color formatting for console outputs connected to a TTY to provide immediate, accessible visual cues.
+
+## 2026-03-05 - Hide Terminal Cursor During Inline Progress
+**Learning:** When using carriage returns (`\r`) to update progress on a single line, the terminal cursor jumps back and forth, creating a distracting flickering effect. Additionally, if an error or keyboard interrupt occurs mid-progress, the error message often appends to the current line, creating messy output.
+**Action:** Use ANSI sequences to hide the cursor (`\033[?25l`) at startup and restore it (`\033[?25h`) on exit (e.g., using `atexit`). Always clear the current line (`\r\033[K`) in top-level exception handlers before printing errors to ensure clean, readable output.

--- a/openfoam_residuals/main.py
+++ b/openfoam_residuals/main.py
@@ -16,6 +16,7 @@ python main.py -w case1 -w case2 -vv --no-plots
 from __future__ import annotations
 
 import argparse
+import atexit
 import logging
 import sys
 from pathlib import Path
@@ -80,6 +81,13 @@ def parse_args() -> argparse.Namespace:
 
 
 # ───────────────────────────── helpers ──────────────────────────────────
+def _restore_cursor() -> None:
+    """Restore the terminal cursor on exit."""
+    if sys.stdout.isatty():
+        sys.stdout.write("\033[?25h")
+        sys.stdout.flush()
+
+
 class _ColorFormatter(logging.Formatter):
     """Custom formatter to add ANSI colors to log levels if outputting to a TTY."""
 
@@ -129,6 +137,12 @@ def gather_from_dirs(dirs: Iterable[str | Path]) -> list[Path]:
 # ───────────────────────────── main routine ─────────────────────────────
 def main() -> None:
     """Parse, compute, and export residual plots."""
+    if sys.stdout.isatty():
+        # Hide cursor to prevent flickering during inline progress updates
+        sys.stdout.write("\033[?25l")
+        sys.stdout.flush()
+        atexit.register(_restore_cursor)
+
     args = parse_args()
     configure_logging(args.verbose)
 
@@ -183,8 +197,14 @@ if __name__ == "__main__":
     try:
         main()
     except KeyboardInterrupt:
+        if sys.stdout.isatty():
+            sys.stdout.write("\r\033[K")
+            sys.stdout.flush()
         _LOG.warning("Interrupted by user - aborting.")
         sys.exit(130)
     except fs.DataParseError as e:
+        if sys.stdout.isatty():
+            sys.stdout.write("\r\033[K")
+            sys.stdout.flush()
         _LOG.error(str(e))
         sys.exit(1)


### PR DESCRIPTION
**💡 What:** 
Added ANSI escape sequences to hide the terminal cursor (`\033[?25l`) at startup and restore it (`\033[?25h`) cleanly via `atexit`. Also modified the top-level exception handlers (`KeyboardInterrupt`, `DataParseError`) to explicitly clear the current line (`\r\033[K`) before logging their errors.

**🎯 Why:** 
When using carriage returns (`\r`) to update progress on a single line, the terminal cursor jumps back and forth rapidly, creating a distracting flickering effect. Additionally, if the user hits `Ctrl+C` or a parsing error occurs mid-progress, the resulting error message or keyboard interrupt would unceremoniously append to the ongoing progress string, resulting in messy, unreadable output.

**📸 Before/After:** 
*Before:* The cursor rapidly flickers at the start/end of the line. On interrupt: `🎨 Plotting 12/100 (U_residuals.dat)... WARNING │ Interrupted by user - aborting.`
*After:* The cursor is invisible during processing. On interrupt, the progress line disappears cleanly before the warning is logged on its own fresh line.

**♿ Accessibility:** 
Improves visual stability by eliminating rapid, distracting visual flickering in the terminal. Enhances readability of error messages by ensuring they are presented clearly on new lines without extraneous inline garbage.

---
*PR created automatically by Jules for task [8542701426992394178](https://jules.google.com/task/8542701426992394178) started by @kastnerp*