### PR TITLE
🎨 Palette: Add gridlines to residual plots for better readability

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2026-03-04 - Clean Progress Indicators and Exception Handling
 **Learning:** In terminal CLIs, inline progress indicators (`\r`) can cause visual flickering of the cursor. Furthermore, exceptions raised during progress can interleave with the progress text, creating confusing and unreadable error logs.
 **Action:** Always hide the cursor (`\033[?25l`) while progress is active, and ensure it is restored on exit (e.g., via `atexit`). When handling top-level exceptions, clear the current progress line (`\r\033[K`) before logging the error to maintain clean output.
+
+## 2026-03-05 - Enhance Logarithmic Plot Readability
+**Learning:** Logarithmic plots without gridlines are difficult to read and track data points back to the axes.
+**Action:** Add major and minor gridlines to logarithmic plots to improve visual tracking and data accessibility.

--- a/openfoam_residuals/plot.py
+++ b/openfoam_residuals/plot.py
@@ -58,6 +58,9 @@ def export_files(
             line.set_label(col_name)
         ax.set_yscale("log")
 
+        ax.grid(visible=True, which="major", alpha=0.6)
+        ax.grid(visible=True, which="minor", alpha=0.2)
+
         ax.legend(loc="upper right")
         ax.set_xlabel("Iterations")
         ax.set_ylabel("Residuals")


### PR DESCRIPTION
💡 What: Added major and minor gridlines to the logarithmic plot generation in `openfoam_residuals/plot.py`.
🎯 Why: Logarithmic plots naturally distort the spacing between values. Without gridlines, users struggle to trace data points horizontally back to the Y-axis to read their exact value.
♿ Accessibility: Improved data visualization accessibility by providing a clear, visual structure (grid) that reduces cognitive load when analyzing non-linear residual data.

---
*PR created automatically by Jules for task [14851601031846352972](https://jules.google.com/task/14851601031846352972) started by @kastnerp*