### PR TITLE
🎨 Palette: Add visual feedback during silent directory scanning

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -21,3 +21,7 @@
 ## 2026-03-04 - Clean Progress Indicators and Exception Handling
 **Learning:** In terminal CLIs, inline progress indicators (`\r`) can cause visual flickering of the cursor. Furthermore, exceptions raised during progress can interleave with the progress text, creating confusing and unreadable error logs.
 **Action:** Always hide the cursor (`\033[?25l`) while progress is active, and ensure it is restored on exit (e.g., via `atexit`). When handling top-level exceptions, clear the current progress line (`\r\033[K`) before logging the error to maintain clean output.
+
+## 2026-03-05 - Avoid Silent Directory Traversals
+**Learning:** Silent directory transversals or async filesystem blocking operations can leave users feeling that the application has frozen. Waiting for subsequent progress indications (like plotting) is not sufficient since finding the files itself could take a while in large directories.
+**Action:** Add visual loading indicators like `\r\033[K📁 Scanning '<dir>'...` whenever recursively searching or blocking on large directory operations.

--- a/openfoam_residuals/main.py
+++ b/openfoam_residuals/main.py
@@ -123,11 +123,22 @@ def configure_logging(verbosity: int) -> None:
 def gather_from_dirs(dirs: Iterable[str | Path]) -> list[Path]:
     """Find all residual files in the provided directories."""
     residual_files: list[Path] = []
+    is_tty = sys.stdout.isatty()
     for work_dir in map(Path, dirs):
         if not work_dir.exists():
             _LOG.error("Work dir %s does not exist -- skipping.", work_dir)
             continue
+
+        if is_tty:
+            sys.stdout.write(f"\r\033[K📁 Scanning '{work_dir}'...")
+            sys.stdout.flush()
+
         files = fs.find_residual_files(work_dir)
+
+        if is_tty:
+            sys.stdout.write("\r\033[K")
+            sys.stdout.flush()
+
         if not files:
             _LOG.warning("No residual files found in %s", work_dir)
         residual_files.extend(files)


### PR DESCRIPTION
### 💡 What
Added a visual loading indicator (`\r\033[K📁 Scanning '<dir>'...`) during the synchronous file system traversal in `openfoam_residuals/main.py` -> `gather_from_dirs()`.

### 🎯 Why
When passing a large root directory to the `-w` flag, `pathlib.Path.rglob()` can block for several seconds while searching for `residuals*.dat` files. Previously, this operation was completely silent, making the CLI feel unresponsive or "frozen" until the actual plotting progress bar kicked in. This small visual feedback reassures the user that the tool is actively working.

### 📸 Before/After
*   **Before:** Silent terminal delay when executing `python main.py -w <large-dir>`.
*   **After:** Immediate display of `📁 Scanning '<large-dir>'...`, which is smoothly cleared once parsing begins.

### ♿ Accessibility
Improves system status visibility (Heuristic #1) and reduces cognitive load by removing the uncertainty of a blank terminal.

---
*PR created automatically by Jules for task [16490241258788431205](https://jules.google.com/task/16490241258788431205) started by @kastnerp*