### PR TITLE
ci: Ensure tests run on all pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Removed the `branches: - main` restriction from the `pull_request` event trigger in the `.github/workflows/main.yml` file. This ensures that the GitHub Actions CI pipeline runs on all pull requests to the repository, not just those targeting the `main` branch, allowing tests to run automatically.

---
*PR created automatically by Jules for task [14703941903085536770](https://jules.google.com/task/14703941903085536770) started by @kastnerp*