### PR TITLE
🎨 Palette: Add gridlines to logarithmic residual plots

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-03-05 - Avoid Silent Directory Traversals
 **Learning:** Silent directory transversals or async filesystem blocking operations can leave users feeling that the application has frozen. Waiting for subsequent progress indications (like plotting) is not sufficient since finding the files itself could take a while in large directories.
 **Action:** Add visual loading indicators like `\r\033[K📁 Scanning '<dir>'...` whenever recursively searching or blocking on large directory operations.
+
+## 2026-03-05 - Enhance Readability of Logarithmic Plots
+**Learning:** When using logarithmic scales, reading values and distinguishing data points across orders of magnitude becomes difficult without visual aids.
+**Action:** Always enable both major and minor gridlines on logarithmic axes (e.g., `ax.grid(visible=True, which="major", alpha=0.6)`) to provide crucial spatial context and improve data readability.

--- a/openfoam_residuals/plot.py
+++ b/openfoam_residuals/plot.py
@@ -58,6 +58,10 @@ def export_files(
             line.set_label(col_name)
         ax.set_yscale("log")
 
+        # 🎨 Palette: Add major and minor gridlines to improve readability of logarithmic plots
+        ax.grid(visible=True, which="major", alpha=0.6)
+        ax.grid(visible=True, which="minor", alpha=0.2)
+
         ax.legend(loc="upper right")
         ax.set_xlabel("Iterations")
         ax.set_ylabel("Residuals")


### PR DESCRIPTION
💡 **What:** Added major and minor gridlines to the generated residual plots.
🎯 **Why:** The residual plots use a logarithmic y-axis (`ax.set_yscale("log")`). Without gridlines, it is extremely difficult to visually estimate values and track data points across different orders of magnitude. Gridlines provide essential spatial context.
📸 **Before/After:** The plots now feature a subtle but clear major and minor grid in the background, making it significantly easier to read the exact magnitudes of the residuals.
♿ **Accessibility:** This is a key improvement for visual data accessibility, as it reduces cognitive load when interpreting the logarithmic scales.

Also documented this finding in `.Jules/palette.md` for future reference.

---
*PR created automatically by Jules for task [949500307457187009](https://jules.google.com/task/949500307457187009) started by @kastnerp*