### PR TITLE
🎨 Palette: Apply colorblind-friendly palette to residual plots

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2026-03-05 - Enhance Readability of Logarithmic Plots
 **Learning:** When using logarithmic scales, reading values and distinguishing data points across orders of magnitude becomes difficult without visual aids.
 **Action:** Always enable both major and minor gridlines on logarithmic axes (e.g., `ax.grid(visible=True, which="major", alpha=0.6)`) to provide crucial spatial context and improve data readability.
+
+## 2026-03-08 - Use Colorblind-Friendly Palettes for Data Visualization
+**Learning:** Default color cycles in plotting libraries often rely on combinations of red, green, and other colors that are indistinguishable for users with various forms of color vision deficiency (e.g., deuteranomaly, protanomaly). When plotting complex data like OpenFOAM residuals with multiple lines, this makes the visualization completely inaccessible to a significant portion of the population.
+**Action:** Always explicitly apply a colorblind-friendly style or palette (like `tableau-colorblind10` in matplotlib) before generating data visualizations to ensure accessibility without sacrificing aesthetics.

--- a/openfoam_residuals/plot.py
+++ b/openfoam_residuals/plot.py
@@ -26,6 +26,9 @@ def export_files(
     total = len(residual_files)
     is_tty = sys.stdout.isatty()
 
+    # 🎨 Palette: Use a colorblind-friendly palette for accessibility
+    plt.style.use("tableau-colorblind10")
+
     # ⚡ Bolt: Create Figure and Axes once and reuse them for all plots.
     # Reusing the same ax object avoids the ~10-15% overhead of instantiating
     # new figure/axes objects and tearing them down in every loop iteration.


### PR DESCRIPTION
💡 **What:** Applied the `tableau-colorblind10` matplotlib style when plotting OpenFOAM residuals.
🎯 **Why:** The default matplotlib color cycle can be difficult for users with various forms of color vision deficiency to distinguish, particularly when viewing plots with multiple overlapping residual lines.
📸 **Before/After:** N/A (Visual change to generated PNGs)
♿ **Accessibility:** Significantly improves the readability of generated data visualizations for users with color vision deficiencies.

---
*PR created automatically by Jules for task [12213805031964148922](https://jules.google.com/task/12213805031964148922) started by @kastnerp*