### PR TITLE
🎨 Palette: Apply colorblind-friendly palette via user setting

### DIFF
--- a/openfoam_residuals/main.py
+++ b/openfoam_residuals/main.py
@@ -71,6 +71,11 @@ def parse_args() -> argparse.Namespace:
         help="Export data files only (skip PNG generation).",
     )
     parser.add_argument(
+        "--colorblind",
+        action="store_true",
+        help="Use a colorblind-friendly palette for the plots.",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         action="count",
@@ -190,6 +195,7 @@ def main() -> None:
             min_val,
             max_iter,
             output_dir=out_dir,
+            colorblind=args.colorblind,
         )
         print(f"✨ Successfully exported {len(residual_files)} plot(s) to {out_dir}")
     else:

--- a/openfoam_residuals/plot.py
+++ b/openfoam_residuals/plot.py
@@ -15,6 +15,8 @@ def export_files(
     min_val: float,
     max_iter: int,
     output_dir: Path | None = None,
+    *,
+    colorblind: bool = False,
 ) -> None:
     """Export PNG plots for all residual files."""
     if output_dir is not None:
@@ -26,8 +28,11 @@ def export_files(
     total = len(residual_files)
     is_tty = sys.stdout.isatty()
 
-    # 🎨 Palette: Use a colorblind-friendly palette for accessibility
-    plt.style.use("tableau-colorblind10")
+    # 🎨 Palette: Optionally use a colorblind-friendly palette for accessibility
+    if colorblind:
+        plt.style.use("tableau-colorblind10")
+    else:
+        plt.style.use("default")
 
     # ⚡ Bolt: Create Figure and Axes once and reuse them for all plots.
     # Reusing the same ax object avoids the ~10-15% overhead of instantiating

--- a/tests/test_batch_plotting.py
+++ b/tests/test_batch_plotting.py
@@ -33,6 +33,7 @@ class TestBatchPlotting(unittest.TestCase):
             min_val,
             max_iter,
             output_dir=cls.TEST_DIR,
+            colorblind=True,
         )
 
     @classmethod


### PR DESCRIPTION
💡 What
Added a `--colorblind` CLI flag that explicitly toggles a colorblind-friendly plotting palette.

🎯 Why
By request, the colorblind-friendly style (`tableau-colorblind10`) should be an opt-in user setting rather than the forced universal default, allowing users who want standard visualizations to keep them without breaking accessibility for those who need it.

♿ Accessibility
Users with color vision deficiencies can now explicitly enable accessible palettes by appending `--colorblind` to their command line workflow.

---
*PR created automatically by Jules for task [16959174600613542895](https://jules.google.com/task/16959174600613542895) started by @kastnerp*