### PR TITLE
🎨 Palette: Add accessible image metadata and visual titles to exported plots

### DIFF
--- a/openfoam_residuals/plot.py
+++ b/openfoam_residuals/plot.py
@@ -41,14 +41,13 @@ def export_files(
     fig, ax = plt.subplots(figsize=(15, 5))
 
     for idx, filepath in enumerate(residual_files):
+        # Show up to 3 path components to give context, since file is usually just "residuals.dat"
+        display_name = (
+            "/".join(filepath.parts[-3:]) if len(filepath.parts) >= 3 else filepath.name
+        )
+
         if is_tty:
             # \033[K clears the line from the cursor to the end
-            # Show up to 3 path components to give context, since file is usually just "residuals.dat"
-            display_name = (
-                "/".join(filepath.parts[-3:])
-                if len(filepath.parts) >= 3
-                else filepath.name
-            )
             sys.stdout.write(
                 f"\r\033[K🎨 Plotting {idx + 1}/{total} ({display_name})..."
             )
@@ -84,18 +83,37 @@ def export_files(
         ax.set_ylabel("Residuals")
         ax.set_ylim(min_val, 1)
         ax.set_xlim(0, max_iter)
+
+        # 🎨 Palette: Add a descriptive title to the plot to ensure that sighted users,
+        # and those viewing the plot out of context (e.g. embedded in a report)
+        # know exactly which simulation file generated these residuals.
+        ax.set_title(f"Residuals: {display_name}")
+
         file_parts = filepath.parts
         wind_dir = file_parts[-4] if len(file_parts) >= 4 else "Dir"
         iteration = file_parts[-2] if len(file_parts) >= 2 else "Iter"
         out_name = f"{idx}_{wind_dir}_{iteration}_residuals.png"
         out_path = output_dir_path / out_name
 
+        # 🎨 Palette: Add embedded Title and Description metadata to the PNG file.
+        # This makes the images accessible to screen readers and indexing tools,
+        # providing crucial context for visually impaired users without requiring
+        # external alt-text attributes.
+        metadata = {
+            "Title": f"Residuals: {display_name}",
+            "Description": f"A logarithmic plot showing the convergence of OpenFOAM residuals over {max_iter} iterations for {display_name}.",
+        }
+
         # ⚡ Bolt: Use a lower compression level for PNG encoding.
         # This speeds up the `savefig` operation by ~25% per image with a
         # minimal increase in output file size, which is critical when batch
         # processing hundreds of high-DPI plots.
         fig.savefig(
-            out_path, dpi=600, bbox_inches="tight", pil_kwargs={"compress_level": 1}
+            out_path,
+            dpi=600,
+            bbox_inches="tight",
+            metadata=metadata,
+            pil_kwargs={"compress_level": 1},
         )
 
     # ⚡ Bolt: Close the figure explicitly after all plots are done


### PR DESCRIPTION
💡 What:
- Refactored `display_name` extraction to be available outside the CLI progress bar logic.
- Added visible plot titles (`ax.set_title(f"Residuals: {display_name}")`) to exported plots.
- Embedded accessibility metadata (`Title` and `Description`) directly into the saved PNG files via `fig.savefig(..., metadata=...)`.

🎯 Why:
Plots are often shared independently of the CLI context (e.g., embedded in reports or presentations). Without a visible title, it is difficult for sighted users to track which residual file generated the plot.

♿ Accessibility:
By embedding metadata directly into the PNG output, visually impaired users utilizing screen readers or accessibility indexing tools will receive a descriptive textual representation of the image ("A logarithmic plot showing the convergence of OpenFOAM residuals..."), rather than encountering an opaque graphical block.

---
*PR created automatically by Jules for task [8376200320378211515](https://jules.google.com/task/8376200320378211515) started by @kastnerp*