### PR TITLE
🎨 Palette: Add percentage progress to batch processing CLI

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -41,3 +41,7 @@
 ## 2026-03-10 - Use Varying Line Styles for Data Visualization
 **Learning:** Depending solely on color to differentiate between multiple lines in a plot makes the visualization inaccessible to users with color vision deficiency, and completely illegible if printed in grayscale.
 **Action:** Always combine color differences with varying line styles (e.g., solid, dashed, dotted, dashdot) when generating multi-line plots to ensure the data can be distinguished through multiple visual channels.
+
+## 2024-05-18 - Improve CLI Progress Feedback
+**Learning:** For batch processing of large numbers of files, displaying progress only as a fraction (e.g., "150/1000") can make it difficult for users to quickly assess overall completion at a glance. Adding a calculated percentage provides much clearer immediate visual feedback regarding how far along the process is.
+**Action:** When creating text-based progress updates in CLI tools, explicitly calculate and display the percentage `[X%]` alongside the current count to improve observability and reduce user anxiety during long-running tasks.

--- a/openfoam_residuals/filesystem.py
+++ b/openfoam_residuals/filesystem.py
@@ -37,7 +37,7 @@ def find_min_and_max_iteration(residual_files: list[Path]) -> tuple[int, int]:
                 "/".join(file.parts[-3:]) if len(file.parts) >= 3 else file.name
             )
             sys.stdout.write(
-                f"\r\033[K🔍 Analyzing {idx + 1}/{total} ({display_name})..."
+                f"\r\033[K🔍 Analyzing {idx + 1}/{total} [{int((idx + 1) / total * 100)}%] ({display_name})..."
             )
             sys.stdout.flush()
 

--- a/openfoam_residuals/plot.py
+++ b/openfoam_residuals/plot.py
@@ -49,7 +49,7 @@ def export_files(
         if is_tty:
             # \033[K clears the line from the cursor to the end
             sys.stdout.write(
-                f"\r\033[K🎨 Plotting {idx + 1}/{total} ({display_name})..."
+                f"\r\033[K🎨 Plotting {idx + 1}/{total} [{int((idx + 1) / total * 100)}%] ({display_name})..."
             )
             sys.stdout.flush()
         data, _ = fs.pre_parse(filepath)


### PR DESCRIPTION
💡 **What:** Added an explicit percentage indicator `[X%]` to the terminal progress lines printed during batch simulation analysis and plotting.
🎯 **Why:** When processing large batches of residual files (e.g. "Analyzing 143/890..."), displaying only fractions provides weak immediate visual feedback on total progress. Computing and displaying the percentage at a glance improves the CLI user experience, providing better observability during potentially long-running processes.
📸 **Before/After:**
Before: `🎨 Plotting 143/890 (residuals.dat)...`
After:  `🎨 Plotting 143/890 [16%] (residuals.dat)...`
♿ **Accessibility:** Reduces cognitive load for users by eliminating the need for mental math to gauge operation completion rate.

---
*PR created automatically by Jules for task [6234920100444257931](https://jules.google.com/task/6234920100444257931) started by @kastnerp*