### PR TITLE
🎨 Palette: Surface key convergence metrics immediately in CLI output

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -49,3 +49,7 @@
 ## 2024-05-20 - Add Clickable Hyperlinks for Terminal Outputs
 **Learning:** Generating files with CLI tools often requires the user to manually copy the generated directory path and paste it into a file explorer or `cd` into it, creating unnecessary friction at the end of a successful run. Modern terminal emulators support clickable hyperlinks via the OSC 8 sequence.
 **Action:** When outputting the final location of generated files/folders, dynamically format the path as a clickable hyperlink (`\033]8;;file://...`) if the output is attached to a TTY, allowing users to open the output directly from their terminal with one click.
+
+## 2025-01-22 - Surface Key Metrics Immediately in CLI
+**Learning:** In batch processing CLIs that evaluate large datasets, users often need to open output files or inspect verbose logs simply to check if a process succeeded logically (e.g. if a simulation converged).
+**Action:** Surface key summarized metrics (like min/max values or global convergence points) immediately in the standard CLI output to provide essential context at a glance, eliminating unnecessary context-switching. Include total execution time so users can gauge overall performance.

--- a/openfoam_residuals/main.py
+++ b/openfoam_residuals/main.py
@@ -19,6 +19,7 @@ import argparse
 import atexit
 import logging
 import sys
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
@@ -158,6 +159,7 @@ def gather_from_dirs(dirs: Iterable[str | Path]) -> list[Path]:
 # ───────────────────────────── main routine ─────────────────────────────
 def main() -> None:
     """Parse, compute, and export residual plots."""
+    start_time = time.perf_counter()
     args = parse_args()
     configure_logging(args.verbose)
 
@@ -188,6 +190,12 @@ def main() -> None:
     min_val, max_iter = fs.find_min_and_max_iteration(residual_files)
     _LOG.info("Global min residual: %g   max iteration: %d", min_val, max_iter)
 
+    # 🎨 Palette: Surface key convergence metrics immediately in the CLI output
+    # so users don't have to guess or check logs to see if their run is stable.
+    print(
+        f"📊 Dataset Summary: {max_iter:,} max iterations | {min_val:g} global min residual"
+    )
+
     # Prepare output folder
     out_dir = Path(args.out).resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -212,8 +220,9 @@ def main() -> None:
                 f"\033]8;;{out_dir.resolve().as_uri()}\033\\{out_dir}\033]8;;\033\\"
             )
 
+        elapsed = time.perf_counter() - start_time
         print(
-            f"✨ Successfully exported {len(residual_files)} plot(s) to {out_display}"
+            f"✨ Successfully exported {len(residual_files)} plot(s) to {out_display} in {elapsed:.1f}s"
         )
     else:
         _LOG.info("Skipping plot generation (--no-plots).")
@@ -224,7 +233,8 @@ def main() -> None:
         final_out_display = (
             f"\033]8;;{out_dir.resolve().as_uri()}\033\\{out_dir}\033]8;;\033\\"
         )
-    _LOG.info("Done - results in %s", final_out_display)
+    elapsed = time.perf_counter() - start_time
+    _LOG.info("Done in %.1fs - results in %s", elapsed, final_out_display)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
💡 What: 
Added a summary print statement displaying `max_iter` and `min_val` directly in the CLI standard output, alongside the total processing execution time.

🎯 Why: 
Users running large batches of OpenFOAM residual files often need to quickly check if a simulation successfully converged (e.g., reaching a low global minimum residual) or if it reached its iteration limit. Previously, they had to open the output files or enable verbose mode to find these metrics. Now, this key context is surfaced immediately at a glance. Adding the execution time also gives users a quick sanity check for the overall performance of their batch run.

📸 Before/After:
**Before:**
```
Processing 14 residual files...
✨ Successfully exported 14 plot(s) to /path/to/exports
```
**After:**
```
Processing 14 residual files...
📊 Dataset Summary: 10,800 max iterations | 1e-07 global min residual
✨ Successfully exported 14 plot(s) to /path/to/exports in 35.9s
```

♿ Accessibility: 
Improves the Developer/Command-Line UX (DX) by immediately surfacing critical contextual data, reducing the cognitive load and friction of context-switching between the terminal and log files.

---
*PR created automatically by Jules for task [5195650424977143417](https://jules.google.com/task/5195650424977143417) started by @kastnerp*