### PR TITLE
🎨 Palette: Add visual progress bars to CLI indicators

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -53,3 +53,7 @@
 ## 2025-01-22 - Surface Key Metrics Immediately in CLI
 **Learning:** In batch processing CLIs that evaluate large datasets, users often need to open output files or inspect verbose logs simply to check if a process succeeded logically (e.g. if a simulation converged).
 **Action:** Surface key summarized metrics (like min/max values or global convergence points) immediately in the standard CLI output to provide essential context at a glance, eliminating unnecessary context-switching. Include total execution time so users can gauge overall performance.
+
+## 2025-05-18 - Visual Progress Bars vs. Percentage Numbers
+**Learning:** In CLI interfaces processing many files (like batch plotting OpenFOAM residuals), purely displaying a percentage number forces users to cognitively read and process numbers to gauge progress. Adding a fixed-width visual progress bar (e.g., `[██████░░░░] 60%`) provides shape-based, instant visual feedback that requires significantly less cognitive load to scan.
+**Action:** When creating text-based progress indicators in CLIs, always include a visual bar component alongside the numeric percentage to improve immediate scannability.

--- a/openfoam_residuals/filesystem.py
+++ b/openfoam_residuals/filesystem.py
@@ -36,8 +36,14 @@ def find_min_and_max_iteration(residual_files: list[Path]) -> tuple[int, int]:
             display_name = (
                 "/".join(file.parts[-3:]) if len(file.parts) >= 3 else file.name
             )
+            pct = (idx + 1) / total
+            # 🎨 Palette: Add a fixed-width Unicode visual progress bar to make
+            # parsing progress instantly scannable without reading numbers.
+            bar_len = 10
+            filled = int(bar_len * pct)
+            bar = "█" * filled + "░" * (bar_len - filled)
             sys.stdout.write(
-                f"\r\033[K🔍 Analyzing {idx + 1}/{total} [{int((idx + 1) / total * 100)}%] ({display_name})..."
+                f"\r\033[K🔍 Analyzing {idx + 1}/{total} [{bar}] {int(pct * 100)}% ({display_name})..."
             )
             sys.stdout.flush()
 

--- a/openfoam_residuals/plot.py
+++ b/openfoam_residuals/plot.py
@@ -49,8 +49,13 @@ def export_files(
 
         if is_tty:
             # \033[K clears the line from the cursor to the end
+            pct = (idx + 1) / total
+            # 🎨 Palette: Provide consistent visual progress bar feedback for plotting.
+            bar_len = 10
+            filled = int(bar_len * pct)
+            bar = "█" * filled + "░" * (bar_len - filled)
             sys.stdout.write(
-                f"\r\033[K🎨 Plotting {idx + 1}/{total} [{int((idx + 1) / total * 100)}%] ({display_name})..."
+                f"\r\033[K🎨 Plotting {idx + 1}/{total} [{bar}] {int(pct * 100)}% ({display_name})..."
             )
             sys.stdout.flush()
         data, _ = fs.pre_parse(filepath)


### PR DESCRIPTION
💡 **What:** Added fixed-width Unicode visual progress bars (`[██████░░░░]`) to the inline progress indicators for both the data parsing and plotting phases in the CLI.

🎯 **Why:** Previously, the CLI only displayed a numeric percentage (e.g., `[60%]`) alongside the file count. Displaying only a percentage number forces users to cognitively read and process numbers to gauge progress. Adding a visual shape provides instant visual feedback that requires significantly less cognitive load to scan, particularly during fast-running batch processing.

📸 **Before/After:**
*Before:*
`🔍 Analyzing 30/50 [60%] (residuals.dat)...`
*After:*
`🔍 Analyzing 30/50 [██████░░░░] 60% (residuals.dat)...`

♿ **Accessibility:** Reduces cognitive load for users monitoring terminal output, providing an alternative, shape-based visual channel for assessing completion rather than relying solely on reading updating numeric text.

---
*PR created automatically by Jules for task [8261635497715985489](https://jules.google.com/task/8261635497715985489) started by @kastnerp*