### PR TITLE
🎨 Palette: Remove top and right plot spines to improve data-ink ratio

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -57,3 +57,7 @@
 ## 2025-05-18 - Visual Progress Bars vs. Percentage Numbers
 **Learning:** In CLI interfaces processing many files (like batch plotting OpenFOAM residuals), purely displaying a percentage number forces users to cognitively read and process numbers to gauge progress. Adding a fixed-width visual progress bar (e.g., `[██████░░░░] 60%`) provides shape-based, instant visual feedback that requires significantly less cognitive load to scan.
 **Action:** When creating text-based progress indicators in CLIs, always include a visual bar component alongside the numeric percentage to improve immediate scannability.
+
+## 2026-03-17 - Improve Data-Ink Ratio in Dense Plots
+**Learning:** Dense data visualizations, especially logarithmic plots with gridlines, can become visually overwhelming. Unnecessary structural elements like top and right axis spines add cognitive noise without providing any additional data value.
+**Action:** Always remove the top and right spines (`ax.spines["top"].set_visible(False)`) in standard 2D plots to maximize the data-ink ratio, reduce visual clutter, and draw the user's focus directly to the plotted data lines.

--- a/openfoam_residuals/plot.py
+++ b/openfoam_residuals/plot.py
@@ -83,6 +83,11 @@ def export_files(
         ax.grid(visible=True, which="major", alpha=0.6)
         ax.grid(visible=True, which="minor", alpha=0.2)
 
+        # 🎨 Palette: Remove top and right spines to reduce visual clutter and
+        # improve the data-ink ratio, allowing users to focus on the data lines.
+        ax.spines["top"].set_visible(False)
+        ax.spines["right"].set_visible(False)
+
         # 🎨 Palette: Move legend outside the plot area to prevent it from obscuring data
         ax.legend(bbox_to_anchor=(1.02, 1), loc="upper left", borderaxespad=0.0)
         ax.set_xlabel("Iterations")


### PR DESCRIPTION
💡 What: Removed the top and right spines from matplotlib plots.
🎯 Why: In dense, logarithmic plots with gridlines, structural elements like bounding box spines add cognitive noise without providing any data value. Maximizing the data-ink ratio helps users focus on the actual convergence curves.
📸 Before/After: Generated PNG plots will no longer have top/right bounding lines.
♿ Accessibility: Reduces visual clutter, which helps with general readability and cognitive load.

---
*PR created automatically by Jules for task [8928098827295380412](https://jules.google.com/task/8928098827295380412) started by @kastnerp*