### PR TITLE
🎨 Palette: Prevent horizontal jitter in terminal progress bars

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -61,3 +61,7 @@
 ## 2026-03-17 - Improve Data-Ink Ratio in Dense Plots
 **Learning:** Dense data visualizations, especially logarithmic plots with gridlines, can become visually overwhelming. Unnecessary structural elements like top and right axis spines add cognitive noise without providing any additional data value.
 **Action:** Always remove the top and right spines (`ax.spines["top"].set_visible(False)`) in standard 2D plots to maximize the data-ink ratio, reduce visual clutter, and draw the user's focus directly to the plotted data lines.
+
+## 2026-04-10 - Right-Align Dynamic Values in CLI Progress Bars
+**Learning:** When displaying inline terminal progress bars, dynamically sized numbers (like `1/100` vs `100/100`, or `1%` vs `100%`) cause the entire progress string to jitter left and right. This constant shifting creates visual noise and makes the output feel unpolished.
+**Action:** Always right-align dynamic numbers in terminal progress updates (e.g., `{idx + 1:>{len(str(total))}}` and `{pct:>3}%`) to keep the progress bar and surrounding text physically stable on the screen.

--- a/openfoam_residuals/filesystem.py
+++ b/openfoam_residuals/filesystem.py
@@ -42,8 +42,10 @@ def find_min_and_max_iteration(residual_files: list[Path]) -> tuple[int, int]:
             bar_len = 10
             filled = int(bar_len * pct)
             bar = "█" * filled + "░" * (bar_len - filled)
+            # 🎨 Palette: Right-align the iteration count and percentage to prevent
+            # the progress string from jittering left and right as numbers grow.
             sys.stdout.write(
-                f"\r\033[K🔍 Analyzing {idx + 1}/{total} [{bar}] {int(pct * 100)}% ({display_name})..."
+                f"\r\033[K🔍 Analyzing {idx + 1:>{len(str(total))}}/{total} [{bar}] {int(pct * 100):>3}% ({display_name})..."
             )
             sys.stdout.flush()
 

--- a/openfoam_residuals/plot.py
+++ b/openfoam_residuals/plot.py
@@ -54,8 +54,10 @@ def export_files(
             bar_len = 10
             filled = int(bar_len * pct)
             bar = "█" * filled + "░" * (bar_len - filled)
+            # 🎨 Palette: Right-align the iteration count and percentage to prevent
+            # the progress string from jittering left and right as numbers grow.
             sys.stdout.write(
-                f"\r\033[K🎨 Plotting {idx + 1}/{total} [{bar}] {int(pct * 100)}% ({display_name})..."
+                f"\r\033[K🎨 Plotting {idx + 1:>{len(str(total))}}/{total} [{bar}] {int(pct * 100):>3}% ({display_name})..."
             )
             sys.stdout.flush()
         data, _ = fs.pre_parse(filepath)


### PR DESCRIPTION
**💡 What:** 
Updated the inline terminal progress bars during the "Analyzing" and "Plotting" phases to use fixed-width string formatting. The current iteration count is right-aligned to match the width of the total count (`{idx + 1:>{len(str(total))}}`), and the percentage is right-aligned to 3 spaces (`{pct:>3}%`).

**🎯 Why:**
Previously, as the numerical values in the progress bar grew (e.g., from `1` to `100`, or `1%` to `100%`), the string's total length fluctuated. This caused the text following the numbers (like the progress bar graphic and filename context) to constantly jitter left and right on the terminal line. Right-aligning the values keeps the output visually stable, significantly improving the perceived polish and readability of the CLI.

**📸 Before/After:**
*Before:*
`🔍 Analyzing 1/100 [░░░░░░░░░░] 1% (residuals.dat)...`
`🔍 Analyzing 10/100 [█░░░░░░░░░] 10% (residuals.dat)...`
`🔍 Analyzing 100/100 [██████████] 100% (residuals.dat)...`
*(The `[` and `(` shifted right over time)*

*After:*
`🔍 Analyzing   1/100 [░░░░░░░░░░]   1% (residuals.dat)...`
`🔍 Analyzing  10/100 [█░░░░░░░░░]  10% (residuals.dat)...`
`🔍 Analyzing 100/100 [██████████] 100% (residuals.dat)...`
*(All elements remain perfectly aligned horizontally)*

**♿ Accessibility:**
Reduces visual noise and motion on the screen. Constant, unpredictable horizontal jitter can be distracting or difficult to track for users with cognitive or visual tracking disabilities. A stable interface reduces cognitive load.

---
*PR created automatically by Jules for task [838354237199603019](https://jules.google.com/task/838354237199603019) started by @kastnerp*