### PR TITLE
🎨 Palette: Surface exact final values in plot legends

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -69,3 +69,7 @@
 ## 2026-04-10 - Right-Align Dynamic Values in CLI Progress Bars
 **Learning:** When displaying inline terminal progress bars, dynamically sized numbers (like `1/100` vs `100/100`, or `1%` vs `100%`) cause the entire progress string to jitter left and right. This constant shifting creates visual noise and makes the output feel unpolished.
 **Action:** Always right-align dynamic numbers in terminal progress updates (e.g., `{idx + 1:>{len(str(total))}}` and `{pct:>3}%`) to keep the progress bar and surrounding text physically stable on the screen.
+
+## 2026-04-12 - Surface Final Values in Plot Legends
+**Learning:** In line plots with logarithmic scales and multiple overlapping traces (like convergence residuals), forcing users to visually trace the end of a line back to the Y-axis to estimate the final value is tedious and error-prone.
+**Action:** When plotting convergence or time-series data where the final value is a critical metric, append the exact final value directly to the legend label (e.g. `Ux (1.2e-04)`) to provide precise, immediate context.

--- a/openfoam_residuals/plot.py
+++ b/openfoam_residuals/plot.py
@@ -81,7 +81,18 @@ def export_files(
         # or by users with color vision deficiency, reducing reliance on color alone.
         line_styles = ["solid", "dashed", "dashdot", "dotted"]
         for i, (line, col_name) in enumerate(zip(lines, data.columns, strict=True)):
-            line.set_label(col_name)
+            # 🎨 Palette: Append the final residual value to the legend label so users
+            # can instantly read convergence endpoints without tracing lines back to the axis.
+            last_valid_idx = data[col_name].last_valid_index()
+            if last_valid_idx is not None:
+                final_val = data[col_name].loc[last_valid_idx]
+                # Handle case where column names are duplicated (returns a Series)
+                if hasattr(final_val, "iloc"):
+                    final_val = final_val.dropna().iloc[-1]
+                line.set_label(f"{col_name} ({float(final_val):.1e})")
+            else:
+                line.set_label(col_name)
+
             if linestyle:
                 line.set_linestyle(line_styles[i % len(line_styles)])
 


### PR DESCRIPTION
💡 What: Extracted the final valid value of each plotted data series and appended it to the legend label in scientific notation (e.g. `Ux (1.2e-04)`). Handled Pandas duplicated column name behavior safely.
🎯 Why: In line plots with logarithmic scales and multiple overlapping traces (like convergence residuals), forcing users to visually trace the end of a line back to the Y-axis to estimate the final value is tedious and error-prone. This change provides precise, immediate context exactly where the user looks for identifying the line.
📸 Before/After: Before, legends showed just the field name (`Ux`, `p`). Now, they show `Ux (1.2e-04)`, `p (9.8e-05)`.
♿ Accessibility: Reduces the visual and cognitive load of interpreting dense, multi-line charts, especially on small screens or for users with vision or cognitive tracking impairments.

---
*PR created automatically by Jules for task [9999219480376186845](https://jules.google.com/task/9999219480376186845) started by @kastnerp*