### PR TITLE
🎨 Palette: Prevent terminal line wrapping from breaking progress bars

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -73,3 +73,6 @@
 ## 2026-04-12 - Surface Final Values in Plot Legends
 **Learning:** In line plots with logarithmic scales and multiple overlapping traces (like convergence residuals), forcing users to visually trace the end of a line back to the Y-axis to estimate the final value is tedious and error-prone.
 **Action:** When plotting convergence or time-series data where the final value is a critical metric, append the exact final value directly to the legend label (e.g. `Ux (1.2e-04)`) to provide precise, immediate context.
+## 2024-06-23 - Prevent Progress Bar Terminal Wrapping
+**Learning:** Terminal line wrapping breaks the `\r` (carriage return) cursor reset, causing progress bars with long strings (like deep file paths) to spam multiple lines instead of updating in place.
+**Action:** Always truncate variable-length string outputs (like file paths) in dynamic `\r` terminal lines using `shutil.get_terminal_size().columns` to ensure they fit within the current window width.

--- a/openfoam_residuals/filesystem.py
+++ b/openfoam_residuals/filesystem.py
@@ -55,9 +55,10 @@ def find_min_and_max_iteration(residual_files: list[Path]) -> tuple[int, int]:
             bar = "█" * filled + "░" * (bar_len - filled)
             # 🎨 Palette: Right-align the iteration count and percentage to prevent
             # the progress string from jittering left and right as numbers grow.
-            sys.stdout.write(
-                f"\r\033[K🔍 Analyzing {idx + 1:>{len(str(total))}}/{total} [{bar}] {int(pct * 100):>3}% ({display_name})..."
-            )
+            # 🎨 Palette: Truncate paths that would cause the terminal line to wrap and break \r
+            base_msg = f"🔍 Analyzing {idx + 1:>{len(str(total))}}/{total} [{bar}] {int(pct * 100):>3}%"
+            safe_name = utils.truncate_path(display_name, len(base_msg))
+            sys.stdout.write(f"\r\033[K{base_msg} ({safe_name})...")
             sys.stdout.flush()
 
         data, _ = pre_parse(file)

--- a/openfoam_residuals/main.py
+++ b/openfoam_residuals/main.py
@@ -223,7 +223,7 @@ def main() -> None:
 
         elapsed = time.perf_counter() - start_time
         print(
-            f"✨ Successfully exported {len(residual_files)} plot(s) to {out_display} in {elapsed:.1f}s"
+            f"✨ Successfully exported {len(residual_files)} plot{plural} to {out_display} in {elapsed:.1f}s"
         )
     else:
         _LOG.info("Skipping plot generation (--no-plots).")

--- a/openfoam_residuals/plot.py
+++ b/openfoam_residuals/plot.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 from matplotlib import ticker
 
 import openfoam_residuals.filesystem as fs
+from openfoam_residuals import utils
 
 
 def export_files(
@@ -62,9 +63,10 @@ def export_files(
             bar = "█" * filled + "░" * (bar_len - filled)
             # 🎨 Palette: Right-align the iteration count and percentage to prevent
             # the progress string from jittering left and right as numbers grow.
-            sys.stdout.write(
-                f"\r\033[K🎨 Plotting {idx + 1:>{len(str(total))}}/{total} [{bar}] {int(pct * 100):>3}% ({display_name})..."
-            )
+            # 🎨 Palette: Truncate paths that would cause the terminal line to wrap and break \r
+            base_msg = f"🎨 Plotting {idx + 1:>{len(str(total))}}/{total} [{bar}] {int(pct * 100):>3}%"
+            safe_name = utils.truncate_path(display_name, len(base_msg))
+            sys.stdout.write(f"\r\033[K{base_msg} ({safe_name})...")
             sys.stdout.flush()
         data, _ = fs.pre_parse(filepath)
 

--- a/openfoam_residuals/utils.py
+++ b/openfoam_residuals/utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import shutil
 
 import numpy as np
 
@@ -17,3 +18,12 @@ def order_of_magnitude(number: float) -> int:
 def roundup(x: float) -> int:
     """Round up to the next hundred."""
     return math.ceil(x / 100.0) * 100
+
+
+def truncate_path(path_str: str, base_msg_len: int = 0) -> str:
+    """Truncate a path string to fit within the terminal width."""
+    term_cols = shutil.get_terminal_size().columns
+    avail = term_cols - base_msg_len - 6  # 6 for " ()..." or similar wrapping chars
+    if avail > 5 and len(path_str) > avail:
+        return "…" + path_str[-(avail - 1) :]
+    return path_str


### PR DESCRIPTION
💡 **What**: Added a `truncate_path` utility function that checks the available terminal width using `shutil.get_terminal_size()` and safely left-truncates long file paths before they are printed. Applied this to the inline `\r` progress indicators in both the scanning/analyzing phase and the plotting phase. Also added grammatical polish for pluralizing "plot(s)" correctly based on the count.

🎯 **Why**: When a path is longer than the terminal width, the text wraps to a new line. The `\r` carriage return only resets the cursor to the beginning of the *current* line, not the previous wrapped lines. This caused the terminal to fill up with hundreds of broken, static progress bars, destroying the visual experience.

📸 **Before/After**: 
* **Before**: Long paths wrap, and each iteration prints a new line, destroying the console output.
* **After**: Paths are intelligently truncated (e.g. `...s/cavity/residuals.dat`) to fit the terminal exactly, keeping the progress bar perfectly smooth on a single line.

♿ **Accessibility**: Improves terminal readability and reduces visual noise/clutter for users, particularly when operating on small screens or tiled window managers.

---
*PR created automatically by Jules for task [3066048715102776268](https://jules.google.com/task/3066048715102776268) started by @kastnerp*