### PR TITLE
🎨 Palette: Improve CLI empty state

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -76,3 +76,7 @@
 ## 2024-06-23 - Prevent Progress Bar Terminal Wrapping
 **Learning:** Terminal line wrapping breaks the `\r` (carriage return) cursor reset, causing progress bars with long strings (like deep file paths) to spam multiple lines instead of updating in place.
 **Action:** Always truncate variable-length string outputs (like file paths) in dynamic `\r` terminal lines using `shutil.get_terminal_size().columns` to ensure they fit within the current window width.
+
+## 2026-04-15 - Improve CLI Empty State
+**Learning:** When a user runs a CLI tool without any arguments, a terse argparse required arguments error hides the helpful docstring examples and flags. This results in a poor onboarding experience for new users who are just trying to figure out how to use the tool.
+**Action:** Always intercept empty invocations (`len(sys.argv) == 1`) and automatically print the full help message (`parser.print_help()`) to act as a helpful "empty state" that provides immediate guidance.

--- a/openfoam_residuals/main.py
+++ b/openfoam_residuals/main.py
@@ -88,6 +88,11 @@ def parse_args() -> argparse.Namespace:
         default=0,
         help="Increase logging verbosity (-v, -vv).",
     )
+
+    if len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
     return parser.parse_args()
 
 


### PR DESCRIPTION
💡 **What**: Automatically prints the full help message when the CLI is run without arguments, instead of throwing a terse `argparse` required-argument error.
🎯 **Why**: When users run a CLI tool for the first time without flags, they often don't know what it expects. The default argparse missing-argument error hides the helpful module docstring (which contains examples) and the list of available flags. Intercepting empty invocations creates a much friendlier "empty state" onboarding experience.
📸 **Before/After**:
**Before:**
```
usage: main.py [-h] (-f FILE | -w DIR) [-o DIR] [--no-plots] [--colorblind] [--linestyle] [-v]
main.py: error: one of the arguments -f/--file -w/--work-dir is required
```
**After:**
Prints the complete usage documentation, including the `Examples` section from the module docstring.

♿ **Accessibility**: Reduces cognitive friction for new users trying to discover the tool's capabilities.

---
*PR created automatically by Jules for task [3613302959372607468](https://jules.google.com/task/3613302959372607468) started by @kastnerp*